### PR TITLE
[Update] Integrate Kamish Tutorial System (BaseMonster)

### DIFF
--- a/Config/DefaultGameplayTags.ini
+++ b/Config/DefaultGameplayTags.ini
@@ -91,6 +91,7 @@ NetIndexFirstBitSegment=16
 +GameplayTagList=(Tag="Tutorial.Gimmick.Tree",DevComment="")
 +GameplayTagList=(Tag="Tutorial.Item.Stone",DevComment="")
 +GameplayTagList=(Tag="Tutorial.Item.Stonepickaxe",DevComment="")
++GameplayTagList=(Tag="Tutorial.Monster.KamishForestBoss",DevComment="")
 +GameplayTagList=(Tag="Weapon.Melee.Chainsaw",DevComment="")
 +GameplayTagList=(Tag="Weapon.Melee.CrystalSword",DevComment="")
 +GameplayTagList=(Tag="Weapon.Melee.DemolitionGear",DevComment="")

--- a/Source/CR4S/MonsterAI/BaseMonster.cpp
+++ b/Source/CR4S/MonsterAI/BaseMonster.cpp
@@ -5,6 +5,7 @@
 #include "BehaviorTree/BlackboardComponent.h"
 #include "BehaviorTree/BehaviorTreeComponent.h"
 #include "Character/Characters/ModularRobot.h"
+#include "Character/Characters/PlayerCharacter.h"
 #include "Components/MonsterAttributeComponent.h"
 #include "Components/MonsterSkillComponent.h"
 #include "Components/MonsterStateComponent.h"
@@ -100,7 +101,7 @@ float ABaseMonster::TakeDamage(float DamageAmount, FDamageEvent const& DamageEve
 	}
 
 	// Apply damage via AttributeComponent
-	AttributeComponent->ApplyDamage(ActualDamage);
+	AttributeComponent->ApplyDamage(ActualDamage, DamageCauser);
 	AddAccumulatedDamage(ActualDamage);
 
 	if (AModularRobot* Robot= Cast<AModularRobot>(DamageCauser))
@@ -134,7 +135,7 @@ bool ABaseMonster::IsDead() const
 	return AttributeComponent && AttributeComponent->IsDead();
 }
 
-void ABaseMonster::HandleDeath()
+void ABaseMonster::HandleDeath(AActor* Killer)
 {
 	if (bIsDead)
 	{
@@ -151,6 +152,9 @@ void ABaseMonster::HandleDeath()
 	StateComponent->SetState(EMonsterState::Dead);
 	OnDied.Broadcast(this);
 
+	// Tutorial Notification
+	NotifyDeathObjective(Killer);
+	
 	if (UBaseInventoryComponent* InventoryComp = GetPlayerInventory())
 	{
 		TryDropItems(InventoryComp);
@@ -333,4 +337,54 @@ void ABaseMonster::PlayHitSound()
 			UGameplayStatics::PlaySoundAtLocation(this, HitSound, GetActorLocation());
 		}
 	}
+}
+
+FGameplayTag ABaseMonster::GetTutorialTag() const
+{
+	if (MonsterID.IsNone())
+	{
+		return FGameplayTag();
+	}
+
+	FString TagString = FString::Printf(TEXT("Tutorial.Monster.%s"), *MonsterID.ToString());;
+	return FGameplayTag::RequestGameplayTag(FName(*TagString), false);
+}
+
+void ABaseMonster::NotifyDeathObjective(AActor* Killer)
+{
+	if (!bEnableTutorialNotify)
+	{
+		return;
+	}
+
+	FGameplayTag TutorialTag = GetTutorialTag();
+	if (!TutorialTag.IsValid())
+	{
+		return;
+	}
+
+	if (IsKilledByPlayer(Killer))
+	{
+		ITutorialNotifiable::NotifyObjective(this, TutorialTag);
+	}
+}
+
+bool ABaseMonster::IsKilledByPlayer(AActor* Killer)
+{
+	if (!IsValid(Killer))
+	{
+		return false;
+	}
+
+	if (Cast<APlayerCharacter>(Killer))
+	{
+		return true;
+	}
+
+	if (AModularRobot* Robot = Cast<AModularRobot>(Killer))
+	{
+		return Robot->GetMountedCharacter() != nullptr;
+	}
+	
+	return false;
 }

--- a/Source/CR4S/MonsterAI/BaseMonster.h
+++ b/Source/CR4S/MonsterAI/BaseMonster.h
@@ -5,6 +5,7 @@
 #include "Game/Interface/Spawnable.h"
 #include "Data/MonsterEnum.h"
 #include "Utility/StunnableInterface.h"
+#include "Game/Interface/TutorialNotifiable.h"
 #include "BaseMonster.generated.h"
 
 class UBaseInventoryComponent;
@@ -27,7 +28,7 @@ struct FDropData
 };
 
 UCLASS()
-class CR4S_API ABaseMonster : public ACharacter, public ISpawnable, public IStunnableInterface
+class CR4S_API ABaseMonster : public ACharacter, public ISpawnable, public IStunnableInterface, public ITutorialNotifiable
 {
 	GENERATED_BODY()
 
@@ -131,7 +132,7 @@ public:
 
 public:
 	UFUNCTION()
-	virtual void HandleDeath();
+	virtual void HandleDeath(AActor* Killer = nullptr);
 
 protected:
 	UFUNCTION()
@@ -187,6 +188,19 @@ protected:
 	float FlashDuration = 0.2f;
 
 	FTimerHandle FlashTimerHandle;
+	
+#pragma endregion
+
+#pragma region Tutorial Notification
+public:
+	virtual FGameplayTag GetTutorialTag() const override;
+
+protected:
+	virtual void NotifyDeathObjective(AActor* Killer);
+	static bool IsKilledByPlayer(AActor* Killer);
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Monster|Tutorial")
+	bool bEnableTutorialNotify = false;
 	
 #pragma endregion
 	

--- a/Source/CR4S/MonsterAI/BossMonster/Season/SeasonBossMonster.cpp
+++ b/Source/CR4S/MonsterAI/BossMonster/Season/SeasonBossMonster.cpp
@@ -76,9 +76,9 @@ float ASeasonBossMonster::TakeDamage(
    return Actual;
 }
 
-void ASeasonBossMonster::HandleDeath()
+void ASeasonBossMonster::HandleDeath(AActor* Killer)
 {
-   Super::HandleDeath();
+   Super::HandleDeath(Killer);
 
    if (SpawnedEnvVolume && SpawnedEnvVolume->IsValidLowLevel())
    {

--- a/Source/CR4S/MonsterAI/BossMonster/Season/SeasonBossMonster.h
+++ b/Source/CR4S/MonsterAI/BossMonster/Season/SeasonBossMonster.h
@@ -21,7 +21,7 @@ public:
 
 protected:
 	virtual void BeginPlay() override;
-	virtual void HandleDeath() override;
+	virtual void HandleDeath(AActor* Killer) override;
 
 #pragma region State Mamaging
 protected:

--- a/Source/CR4S/MonsterAI/Components/MonsterAttributeComponent.cpp
+++ b/Source/CR4S/MonsterAI/Components/MonsterAttributeComponent.cpp
@@ -45,9 +45,9 @@ void UMonsterAttributeComponent::InitializeMonsterAttribute(const FName MonsterI
 	CurrentHP = 0.0f;
 }
 
-void UMonsterAttributeComponent::ApplyDamage(float DamageAmount)
+void UMonsterAttributeComponent::ApplyDamage(float DamageAmount, AActor* DamageCauser)
 {
-	ChangeHP(-FMath::Abs(DamageAmount));
+	ChangeHP(-FMath::Abs(DamageAmount), DamageCauser);
 }
 
 void UMonsterAttributeComponent::ApplyHeal(float HealAmount)
@@ -55,7 +55,7 @@ void UMonsterAttributeComponent::ApplyHeal(float HealAmount)
 	ChangeHP(FMath::Abs(HealAmount));
 }
 
-void UMonsterAttributeComponent::ChangeHP(float Delta)
+void UMonsterAttributeComponent::ChangeHP(float Delta, AActor* DamageCauser)
 {
 	CurrentHP = FMath::Clamp(CurrentHP + Delta, 0.0f, CurrentAttribute.MaxHP);
 
@@ -70,7 +70,7 @@ void UMonsterAttributeComponent::ChangeHP(float Delta)
 	{
 		if (OnDeath.IsBound())
 		{
-			OnDeath.Broadcast();
+			OnDeath.Broadcast(DamageCauser);
 		}
 	}
 }

--- a/Source/CR4S/MonsterAI/Components/MonsterAttributeComponent.h
+++ b/Source/CR4S/MonsterAI/Components/MonsterAttributeComponent.h
@@ -7,7 +7,7 @@
 
 class UDataTable;
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnMonsterDeath);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnMonsterDeath, AActor*, Killer);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnMonsterHPChanged, float, CurrentHP, float, MaxHP);
 
 UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
@@ -23,7 +23,7 @@ public:
 	void InitializeMonsterAttribute(const FName MonsterID);
 
 	UFUNCTION(BlueprintCallable, Category = "Attributes")
-	void ApplyDamage(float DamageAmount);
+	void ApplyDamage(float DamageAmount, AActor* DamageCauser = nullptr);
 
 	UFUNCTION(BlueprintCallable, Category = "Attributes")
 	void ApplyHeal(float HealAmount);
@@ -58,7 +58,7 @@ protected:
 	virtual void BeginPlay() override;
 
 private:
-	void ChangeHP(float Delta);
+	void ChangeHP(float Delta, AActor* DamageCauser = nullptr);
 	FString MyHeader;
 	
 };

--- a/Source/CR4S/MonsterAI/Components/MonsterStateComponent.cpp
+++ b/Source/CR4S/MonsterAI/Components/MonsterStateComponent.cpp
@@ -139,7 +139,7 @@ void UMonsterStateComponent::AddStun(float StunAmount)
 	
 	CurrentStun = FMath::Clamp(CurrentStun + StunAmount, 0.f, MaxStun);
 	OnStunChangedDelegate.Broadcast();
-	CR4S_Log(LogMonster, Log, TEXT("[Stun] Add Stun - CurrentStun=%.2f / MaxStun=%.2f"), CurrentStun, MaxStun);
+	// CR4S_Log(LogMonster, Log, TEXT("[Stun] Add Stun - CurrentStun=%.2f / MaxStun=%.2f"), CurrentStun, MaxStun);
 
 	bCanRecover = false;
 	GetWorld()->GetTimerManager().ClearTimer(RecoveryDelayTimerHandle);

--- a/Source/CR4S/MonsterAI/Manager/MonsterHealthManager.cpp
+++ b/Source/CR4S/MonsterAI/Manager/MonsterHealthManager.cpp
@@ -192,7 +192,7 @@ void UMonsterHealthManager::OnMonsterSpawned(AActor* SpawnedMonster)
 	}
 }
 
-void UMonsterHealthManager::OnMonsterDestroyed()
+void UMonsterHealthManager::OnMonsterDestroyed(AActor* Killer)
 {
 	RefreshAllHealthBars();
 }

--- a/Source/CR4S/MonsterAI/Manager/MonsterHealthManager.h
+++ b/Source/CR4S/MonsterAI/Manager/MonsterHealthManager.h
@@ -52,5 +52,5 @@ private:
 	void OnMonsterSpawned(AActor* SpawnedMonster);
 
 	UFUNCTION()
-	void OnMonsterDestroyed();
+	void OnMonsterDestroyed(AActor* Killer);
 };

--- a/Source/CR4S/MonsterAI/Region/KamishForestBoss.cpp
+++ b/Source/CR4S/MonsterAI/Region/KamishForestBoss.cpp
@@ -53,7 +53,7 @@ void AKamishForestBoss::OnMonsterStateChanged(EMonsterState Previous, EMonsterSt
 	}
 }
 
-void AKamishForestBoss::HandleDeath()
+void AKamishForestBoss::HandleDeath(AActor* Killer)
 {
 	for (auto Weapon : WeaponActors)
 	{
@@ -67,7 +67,7 @@ void AKamishForestBoss::HandleDeath()
 	VisualWeaponActor = nullptr;
 
 	DestroyActiveClouds();
-	Super::HandleDeath();
+	Super::HandleDeath(Killer);
 }
 
 void AKamishForestBoss::AttachWeaponActor()

--- a/Source/CR4S/MonsterAI/Region/KamishForestBoss.h
+++ b/Source/CR4S/MonsterAI/Region/KamishForestBoss.h
@@ -19,7 +19,7 @@ public:
 protected:
 	virtual void BeginPlay() override;
 	virtual void OnMonsterStateChanged(EMonsterState Previous, EMonsterState Current) override;
-	virtual void HandleDeath() override;
+	virtual void HandleDeath(AActor* Killer) override;
 
 	void AttachWeaponActor();
 	void SpawnCloudEffect();

--- a/Source/CR4S/MonsterAI/UI/MonsterHPBarWidget.cpp
+++ b/Source/CR4S/MonsterAI/UI/MonsterHPBarWidget.cpp
@@ -61,7 +61,7 @@ void UMonsterHPBarWidget::UpdateHPBar(float CurrentHP, float MaxHP)
 	HPText->SetText(FText::FromString(HPString));
 }
 
-void UMonsterHPBarWidget::OnMonsterDeath()
+void UMonsterHPBarWidget::OnMonsterDeath(AActor* Killer)
 {
 	SetVisibility(ESlateVisibility::Hidden);
 	UnbindFromMonster();

--- a/Source/CR4S/MonsterAI/UI/MonsterHPBarWidget.h
+++ b/Source/CR4S/MonsterAI/UI/MonsterHPBarWidget.h
@@ -22,7 +22,7 @@ public:
 	void UnbindFromMonster();
 
 	UFUNCTION()
-	void OnMonsterDeath();
+	void OnMonsterDeath(AActor* Killer);
 
 	UFUNCTION()
 	void OnMonsterChangedHPBar(float CurrentHP, float MaxHP);


### PR DESCRIPTION
## #️⃣ Issue Number

#4

## 📝 요약(Summary)

#01. GameplayTag 기반 몬스터 처치 튜토리얼 추가 (BaseMonster)
#02. 마지막 처치 시 플레이어에 의한 공격인지 확인하기 위한 델리게이트 파라미터 수정

BaseMonster의 MonsterID로 GameplayTag 생성 후 전달
확장성을 위해 bEnableTutorialNotify 체크 할 경우만 노티파이 활성화
플레이어, 탑승 로봇으로 처치 시 완료되도록 HandleDeath 및 관련 델리게이트 함수 파라미터 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

다혜님: BaseMonster, SeasonBossMonster 등 일부 델리게이트 파라미터 추가로 인해 코드 수정이 있습니다. 이상 있을 경우 알려주세요.
머지는 승환님 부탁드립니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
