### PR TITLE
[Fix] Clear AI focus on death and snap region boss to ground

### DIFF
--- a/Source/CR4S/MonsterAI/BaseMonster.cpp
+++ b/Source/CR4S/MonsterAI/BaseMonster.cpp
@@ -161,12 +161,18 @@ void ABaseMonster::HandleDeath(AActor* Killer)
 	}
 
 	if (UCharacterMovementComponent* MoveComp = GetCharacterMovement())
+	{
 		MoveComp->DisableMovement();
+		MoveComp->bOrientRotationToMovement = false;
+		MoveComp->bUseControllerDesiredRotation = false;
+	}
 
 	if (ABaseMonsterAIController* AIC = Cast<ABaseMonsterAIController>(GetController()))
 	{
 		AIC->StopMovement();
-		
+		AIC->ClearFocus(EAIFocusPriority::Gameplay);
+		AIC->SetFocus(nullptr);
+
 		if (UBehaviorTreeComponent* BTComp = AIC->FindComponentByClass<UBehaviorTreeComponent>())
 			BTComp->StopTree(EBTStopMode::Safe);
 

--- a/Source/CR4S/MonsterAI/Region/RegionBossMonster.cpp
+++ b/Source/CR4S/MonsterAI/Region/RegionBossMonster.cpp
@@ -11,6 +11,7 @@
 #include "Components/SkeletalMeshComponent.h"
 #include "Kismet/KismetMathLibrary.h"
 #include "NavigationInvokerComponent.h"
+#include "AIController.h"
 #include "CR4S.h"
 
 ARegionBossMonster::ARegionBossMonster()
@@ -239,4 +240,57 @@ void ARegionBossMonster::HandlePhaseChanged(EBossPhase NewPhase)
 
 	UE_LOG(LogMonster, Log, TEXT("[%s] HandlePhaseChanged : Current phase changed to %s"), *MyHeader,
 		*UEnum::GetDisplayValueAsText(NewPhase).ToString());
+}
+
+void ARegionBossMonster::HandleDeath(AActor* Killer)
+{
+	// If in air, find ground and teleport BEFORE parent call
+	if (UCharacterMovementComponent* MoveComp = GetCharacterMovement())
+	{
+		if (!MoveComp->IsMovingOnGround())
+		{
+			// Trace down to find ground
+			FHitResult GroundHit;
+			const FVector Start = GetActorLocation();
+			const FVector End = Start - FVector(0.f, 0.f, 10000.f); // Trace 100m down
+
+			FCollisionQueryParams Params;
+			Params.AddIgnoredActor(this);
+
+			if (GetWorld()->LineTraceSingleByChannel(GroundHit, Start, End, ECC_WorldStatic, Params))
+			{
+				// Teleport to ground
+				FVector GroundLocation = GroundHit.ImpactPoint;
+				GroundLocation.Z += GetCapsuleComponent()->GetScaledCapsuleHalfHeight(); // Offset by capsule height
+
+				SetActorLocation(GroundLocation, false, nullptr, ETeleportType::TeleportPhysics);
+
+				UE_LOG(LogMonster, Log, TEXT("[%s] Monster died in air - teleported to ground at Z=%.2f"),
+					*MyHeader, GroundLocation.Z);
+			}
+			else
+			{
+				UE_LOG(LogMonster, Warning, TEXT("[%s] Monster died in air but no ground found!"), *MyHeader);
+			}
+		}
+	}
+
+	// Call parent implementation (this disables collision)
+	Super::HandleDeath(Killer);
+
+	// Disable rotation towards player
+	if (AAIController* AIC = Cast<AAIController>(GetController()))
+	{
+		AIC->ClearFocus(EAIFocusPriority::Gameplay);
+		AIC->SetFocus(nullptr);
+
+		if (UCharacterMovementComponent* MoveComp = GetCharacterMovement())
+		{
+			MoveComp->bOrientRotationToMovement = false;
+			MoveComp->bUseControllerDesiredRotation = false;
+		}
+	}
+
+	// Hide combat range visualizer
+	HideCombatRange();
 }

--- a/Source/CR4S/MonsterAI/Region/RegionBossMonster.h
+++ b/Source/CR4S/MonsterAI/Region/RegionBossMonster.h
@@ -21,7 +21,8 @@ public:
 
 protected:
 	virtual void BeginPlay() override;
-	virtual void OnMonsterStateChanged(EMonsterState Previous, EMonsterState Current) override;	
+	virtual void OnMonsterStateChanged(EMonsterState Previous, EMonsterState Current) override;
+	virtual void HandleDeath(AActor* Killer = nullptr) override;
 
 	UFUNCTION()
 	void HandlePhaseChanged(EBossPhase NewPhase);


### PR DESCRIPTION
## #️⃣ Issue Number

#2

## 📝 요약(Summary)

- 사망 애니메이션 재생 중 AIController 포커스 해제로 플레이어 방향 회전하는 버그 수정
- 지역 보스가 공중에서 사망 애니메이션 재생되는 문제 수정 (공중일 경우 지면으로 텔레포트)

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

몬스터 사망 이후 플레이어가 이동하면 사망 애니메이션 재생하면서 이동하는 버그가 있어 BaseMonster에서 AIController의 포커스 해제 하는 로직 추가하였습니다.